### PR TITLE
added lib/moleculer_config to handle nats configuration

### DIFF
--- a/index.js
+++ b/index.js
@@ -194,11 +194,11 @@ async function getNodeId(serviceName) {
         if (m[1]) {
           return `${serviceName}-${m[1].substr(0, 8)}`;
         }
-      } 
+      }
       else {
         console.log('missing com.amazonaws.ecs.task-arn label from metadata');
       }
-    } 
+    }
     else {
       console.log('ECS_CONTAINER_METADATA_URI is missing from environment, use random nodeid.');
     }

--- a/lib/moleculer_config.js
+++ b/lib/moleculer_config.js
@@ -1,0 +1,12 @@
+module.exports = {
+  getNatsConfig: (envvar = 'NATS_CLUSTER', defaultVal = 'NATS') => {
+    if (!process.env[envvar]) {
+      return process.env.TRANSPORTER || defaultVal;
+    }
+    const servers = process.env[envvar].split(',').map(v => v.replace(/ /g,''));
+    return {
+      type: 'NATS',
+      options: { servers }
+    };
+  }
+};


### PR DESCRIPTION
The current moleculer runner implementation will allow a single NATS server to be passed via the TRANSPORTER env variable, but does not support handling a multi-server cluster type configuration via the environment.  Ultimately we may want to look at fully replacing moleculer runner with our own version that does much of what the svcenv command line utility is doing.  Until that time, this adds a lib file which can be used as a workaround.

I've added svcenv to all the service projects, so to support a NATS cluster going forward we'd..

1. Update the service to use the version of svcenv with this new lib function.

2. Change the moleculer.config.js in each project

from
```
transporter: "NATS",
```
to
```
transporter: require(svcenv/lib/moleculer_config.js').getNatsConfig(),
```

3. Update the Secrets in  the SecretManager, removing the TRANSPORTER env variable, and adding a new one...
```
NATS_CLUSTER="nats://host:port, nats://host:port, nats://host:port"
```

NOTE 1:  The environment variable ```TRANSPORTER``` overrides whatever is in the ```transporter``` property of moleculer.config.js so if it is left in place, it will override the ```NATS_CLUSTER``` setting.

NOTE 2:  The script will fallback to using the ```TRANSPORTER``` variable before falling back to the default ("NATS").  So this change can be deployed to the service ahead of replacing ```TRANSPORTER``` with ```NATS_CLUSTER``` in the secretmanager.